### PR TITLE
Move access to `cpuid` and MSR instructions into their own types

### DIFF
--- a/hal/src/instructions/cpuid.rs
+++ b/hal/src/instructions/cpuid.rs
@@ -1,0 +1,37 @@
+use core::{
+    arch::x86_64::{CpuidResult, __cpuid},
+    ops::BitXor,
+};
+
+use crate::registers::rflags::RFlags;
+
+#[derive(Clone, Copy)]
+pub struct Cpuid(());
+
+impl Cpuid {
+    /// Returns `Some(Cpuid)` if the CPU supports the `cpuid` instruction.
+    pub fn new() -> Option<Self> {
+        let before = RFlags::read();
+        unsafe {
+            RFlags::write(before.bitxor(RFlags::ID));
+        }
+        let after = RFlags::read();
+
+        // restore old bitflags
+        unsafe {
+            RFlags::write(before);
+        }
+
+        (after != before).then_some(Cpuid(()))
+    }
+
+    /// Get the result of the `cpuid` instruction for the given `leaf`
+    ///
+    /// # Safety
+    /// `leaf` must be valid for this CPU.
+    pub unsafe fn get(self, leaf: u32) -> CpuidResult {
+        // Safety: This requires an instance of Cpuid, which means that cpuid is available.
+        // The caller guarantees that `leaf` is valid.
+        unsafe { __cpuid(leaf) }
+    }
+}

--- a/hal/src/instructions/mod.rs
+++ b/hal/src/instructions/mod.rs
@@ -1,0 +1,1 @@
+pub mod cpuid;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -2,6 +2,7 @@
 
 use core::arch::asm;
 
+pub mod instructions;
 pub mod interrupts;
 pub mod registers;
 

--- a/hal/src/registers/msr/efer.rs
+++ b/hal/src/registers/msr/efer.rs
@@ -59,4 +59,13 @@ impl Efer {
     pub fn nx_available(cpuid: Cpuid) -> bool {
         unsafe { cpuid.get(0x80000001) }.edx & (1 << 20) != 0
     }
+
+    /// Write `self` to MSR.
+    ///
+    /// # Safety
+    /// This must be called in privilege level 0.
+    /// If `self` contains `Efer::NXE`, NXE must be available on this CPU.
+    pub unsafe fn write_unchecked(self, msr: Msr) {
+        unsafe { msr.write(Self::MSR_INDEX, self.bits()) }
+    }
 }

--- a/hal/src/registers/msr/mod.rs
+++ b/hal/src/registers/msr/mod.rs
@@ -1,105 +1,35 @@
 pub mod efer;
-
-use core::{
-    arch::{asm, x86_64::__cpuid},
-    ops::BitXor,
-};
+pub mod msr_guard;
 
 use bitflags::Flags;
+use msr_guard::Msr;
 
-use super::rflags::RFlags;
-
-fn cpuid_available() -> bool {
-    let before = RFlags::read();
-    unsafe {
-        RFlags::write(before.bitxor(RFlags::ID));
-    }
-    let after = RFlags::read();
-
-    // restore old bitflags
-    unsafe {
-        RFlags::write(before);
-    }
-
-    after != before
-}
-
-/// Check whether or not a CPU supports model specific registers (CPUID.01h:EDX[bit 5]). May fail
-/// if cpuid instruction is not available
-fn cpu_has_msr() -> Result<bool, MsrError> {
-    if cpuid_available() {
-        // EAX=1: Processor Info and Feature Bits, bit 5 = MSR support
-        Ok(unsafe { __cpuid(0x1).edx & (1 << 5) != 0 })
-    } else {
-        Err(MsrError::NoCpuid)
-    }
-}
-
-pub trait ModelSpecificRegister: Sized + Flags<Bits = u64> {
+/// An MSR register.
+///
+/// # Safety
+/// MSR_INDEX must be a valid index.
+pub unsafe trait ModelSpecificRegister: Sized + Flags<Bits = u64> {
     const MSR_INDEX: u32;
+    type ReadError;
+    type WriteError;
 
     /// Read a specific register if MSR feature is available to CPU. Returns an error value on
     /// failure.
-    fn read() -> Result<Self, MsrError> {
-        if cpu_has_msr()? {
-            Ok(Self::from_bits_truncate(unsafe { Self::read_raw() }))
-        } else {
-            Err(MsrError::MsrFeatureMissing)
-        }
+    ///
+    /// # Safety
+    /// Caller must be in privilege level 0.
+    unsafe fn read(msr: Msr) -> Result<Self, Self::ReadError> {
+        Ok(Self::from_bits_truncate(unsafe {
+            msr.read(Self::MSR_INDEX)
+        }))
     }
 
     /// Write a specific register if MSR feature is available to CPU. Returns an error value on failure.
-    fn write(self) -> Result<(), MsrError> {
-        if cpu_has_msr()? {
-            unsafe { Self::write_raw(self.bits()) }
-            Ok(())
-        } else {
-            Err(MsrError::MsrFeatureMissing)
-        }
-    }
-
-    /// Retrieve a 64-bit model specific register
     ///
     /// # Safety
-    /// Caller must specify a valid index and be in privilege level 0.
-    #[inline]
-    unsafe fn read_raw() -> u64 {
-        let (high, low): (u32, u32);
-        unsafe {
-            asm!(
-                "rdmsr",
-                in("ecx") Self::MSR_INDEX,
-                out("eax") low, out("edx") high,
-                options(nomem, nostack, preserves_flags),
-            );
-        }
-        ((high as u64) << 32) | (low as u64)
+    /// Caller must be in privilege level 0.
+    unsafe fn write(self, msr: Msr) -> Result<(), Self::WriteError> {
+        unsafe { msr.write(Self::MSR_INDEX, self.bits()) };
+        Ok(())
     }
-
-    /// Write a 64-bit model specific register
-    ///
-    /// # Safety
-    /// Caller must specify a valid register value and be in privilege level 0.
-    #[inline]
-    unsafe fn write_raw(val: u64) {
-        let low = val as u32;
-        let high = (val >> 32) as u32;
-
-        unsafe {
-            asm!(
-                "wrmsr",
-                in("ecx") Self::MSR_INDEX,
-                in("eax") low, in("edx") high,
-                options(nostack, preserves_flags),
-            );
-        }
-    }
-}
-
-#[derive(Debug, thiserror_no_std::Error)]
-pub enum MsrError {
-    #[error("CPUID instruction unavailable")]
-    NoCpuid,
-    #[error("MSR CPU Feature not available")]
-    MsrFeatureMissing,
 }

--- a/hal/src/registers/msr/msr_guard.rs
+++ b/hal/src/registers/msr/msr_guard.rs
@@ -1,0 +1,54 @@
+use core::arch::asm;
+
+use crate::instructions::cpuid::Cpuid;
+
+#[derive(Clone, Copy)]
+pub struct Msr(Cpuid);
+
+impl Msr {
+    /// Returns `Some(Msr)` if CPU supports model specific registers (CPUID.01h:EDX[bit 5]).
+    pub fn new(cpuid: Cpuid) -> Option<Msr> {
+        let available = unsafe { cpuid.get(0x1) }.edx & (1 << 5) != 0;
+        available.then_some(Msr(cpuid))
+    }
+
+    pub fn get_cpuid(self) -> Cpuid {
+        self.0
+    }
+
+    /// Reads a 64-bit Model-Specific Register (MSR) at the given `index`.
+    ///
+    /// # Safety
+    /// Caller must specify a valid index and be in privilege level 0.
+    pub unsafe fn read(self, index: u32) -> u64 {
+        let (high, low): (u32, u32);
+        unsafe {
+            asm!(
+                "rdmsr",
+                in("ecx") index,
+                out("eax") low, out("edx") high,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        ((high as u64) << 32) | (low as u64)
+    }
+
+    /// Write a 64-bit model specific register
+    ///
+    /// # Safety
+    /// Caller must specify a valid register value and be in privilege level 0.
+    #[inline]
+    pub unsafe fn write(self, index: u32, val: u64) {
+        let low = val as u32;
+        let high = (val >> 32) as u32;
+
+        unsafe {
+            asm!(
+                "wrmsr",
+                in("ecx") index,
+                in("eax") low, in("edx") high,
+                options(nostack, preserves_flags),
+            );
+        }
+    }
+}

--- a/uefi-loader/src/error.rs
+++ b/uefi-loader/src/error.rs
@@ -1,5 +1,4 @@
 use framebuffer::error::FrameBufferError;
-use hal::registers::msr::MsrError;
 use mem::error::FrameAllocatorError;
 
 #[derive(Debug, thiserror_no_std::Error)]
@@ -48,8 +47,6 @@ pub(crate) enum ElfParseError {
 
 #[derive(Debug, thiserror_no_std::Error)]
 pub(crate) enum VasError {
-    #[error("Msr error: {0}")]
-    Msr(#[from] MsrError),
     #[error("Frame Allocator error: {0}")]
     FrameAllocator(#[from] FrameAllocatorError),
 }

--- a/uefi-loader/src/main.rs
+++ b/uefi-loader/src/main.rs
@@ -17,6 +17,7 @@ use graphics::{
     logger::{self, LOGGER},
     parse_psf_font, CAPTION,
 };
+use hal::{instructions::cpuid::Cpuid, registers::msr::msr_guard::Msr};
 use log::{error, info};
 use mem::{bitmap_allocator::BitMapAllocator, KERNEL_STACK_SIZE, PAGE_SIZE};
 use memory::{
@@ -133,12 +134,15 @@ fn main() -> Status {
                 " [LOG  ]: Initializing higher-half kernel address space "
             );
 
+            let cpuid = Cpuid::new();
+            let msr = cpuid.and_then(|x| Msr::new(x));
             let vas = memory::initialize_address_space(
                 bootinfo_ptr.as_ptr(),
                 pmm,
                 kernel_stack,
                 fb_addr,
                 fb_page_num,
+                msr,
             )
             .expect("Error during `initialize_address_space`");
 

--- a/uefi-loader/src/memory/mod.rs
+++ b/uefi-loader/src/memory/mod.rs
@@ -57,10 +57,8 @@ pub(crate) fn initialize_address_space(
                 efer.insert(Efer::NXE);
                 bootinfo_ref.nx = true;
 
-                // Safety: We are in privilege level 0.
-                unsafe {
-                    efer.write(msr).unwrap();
-                }
+                // Safety: We are in privilege level 0 and checked Efer::nx_available above.
+                unsafe { efer.write_unchecked(msr) };
             }
         }
     }


### PR DESCRIPTION
Moved a lot of stuff from `hal/src/registers/msr/mod.rs` into seperate modules.

Access to `cpuid`, `rdmsr` and `wrmsr` are now in their own types (`Cpuid` and `Msr`).
These can be created using their `new` function, which returns `Some` if the CPU supports the feature.

Functions that require one of these optional instructions should take the required type as a parameter.

This makes it a lot more difficult to accidentally use a feature that isn't available and can help avoid duplicate checks. 
